### PR TITLE
Remove node: prefix from worker script

### DIFF
--- a/src/extractPagefileData.ts
+++ b/src/extractPagefileData.ts
@@ -149,8 +149,8 @@ export async function extractPagefileData(
       root,
       `
 
-import { parentPort } from 'node:worker_threads';
-import { exit } from 'node:process';
+import { parentPort } from 'worker_threads';
+import { exit } from 'process';
 
 ${pathImports}
 
@@ -161,7 +161,7 @@ parentPort.once('message', async () => {
 
       `.trim()
     ),
-    [...paths, "node:worker_threads", "node:process", "entrypoint.js"]
+    [...paths, "worker_threads", "process", "entrypoint.js"]
   );
 
   let buildResult: esbuild.BuildResult;


### PR DESCRIPTION
Improves compat with node runtimes that don't support the namespace format.